### PR TITLE
Optional TCP MSS option (--tcpmss)

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -1370,6 +1370,13 @@ static int SET_nobanners(struct Masscan *masscan, const char *name, const char *
     return CONF_OK;
 }
 
+static int SET_tcpmss(struct Masscan *masscan, const char *name, const char *value)
+{
+    UNUSEDPARM(name);
+    masscan->is_tcpmss = parseBoolean(value);
+    return CONF_OK;
+}
+
 static int SET_noreset(struct Masscan *masscan, const char *name, const char *value)
 {
     UNUSEDPARM(name);
@@ -1929,6 +1936,7 @@ struct ConfigParameter config_parameters[] = {
     {"shard",           SET_shard,              0,      {"shards",0}},
     {"banners",         SET_banners,            F_BOOL, {"banner",0}},
     {"nobanners",       SET_nobanners,          F_BOOL, {"nobanner",0}},
+    {"tcpmss",          SET_tcpmss,             F_BOOL, {"tcpmss",0}},
     {"retries",         SET_retries,            0,      {"retry", "max-retries", "max-retry", 0}},
     {"noreset",         SET_noreset,            F_BOOL, {0}},
     {"nmap-payloads",   SET_nmap_payloads,      0,      {"nmap-payload",0}},

--- a/src/main.c
+++ b/src/main.c
@@ -1302,7 +1302,8 @@ main_scan(struct Masscan *masscan)
                     masscan->payloads.udp,
                     masscan->payloads.oproto,
                     stack_if_datalink(masscan->nic[index].adapter),
-                    masscan->seed);
+                    masscan->seed,
+                    masscan->is_tcpmss);
 
         /*
          * Set the "source port" of everything we transmit.

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -183,6 +183,7 @@ struct Masscan
     unsigned is_pfring:1;       /* --pfring */
     unsigned is_sendq:1;        /* --sendq */
     unsigned is_banners:1;      /* --banners */
+    unsigned is_tcpmss:1;       /* --tcpmss */
     unsigned is_offline:1;      /* --offline */
     unsigned is_noreset:1;      /* --noreset, don't transmit RST */
     unsigned is_gmt:1;          /* --gmt, all times in GMT */

--- a/src/templ-pkt.c
+++ b/src/templ-pkt.c
@@ -425,6 +425,7 @@ tcp_create_packet(
         unsigned char *px, size_t px_length)
 {
     uint64_t xsum;
+
     if (ip_them.version == 4) {
         unsigned ip_id = ip_them.ipv4 ^ port_them ^ seqno;
         unsigned offset_ip = tmpl->ipv4.offset_ip;
@@ -439,8 +440,8 @@ tcp_create_packet(
             return 0;
         }
 
-        memcpy(px + 0,              tmpl->ipv4.packet,  tmpl->ipv4.length);
-        memcpy(px + offset_payload, payload,            payload_length);
+        memcpy(px + 0, tmpl->ipv4.packet, tmpl->ipv4.length);
+        memcpy(px + offset_payload, payload, payload_length);
         old_len = px[offset_ip+2]<<8 | px[offset_ip+3];
 
         /*
@@ -1144,7 +1145,7 @@ _template_init_ipv6(struct TemplatePacket *tmpl, macaddress_t router_mac_ipv6, u
      * contents = everything after IPv4/IPv6 header */
     offset_tcp6 = offset_ip + 40;
     memmove(buf + offset_tcp6,
-            buf + offset_tcp,       
+            buf + offset_tcp,
             payload_length
             );
 

--- a/src/templ-pkt.h
+++ b/src/templ-pkt.h
@@ -115,7 +115,8 @@ template_packet_init(
     struct PayloadsUDP *udp_payloads,
     struct PayloadsUDP *oproto_payloads,
     int data_link,
-    uint64_t entropy);
+    uint64_t entropy,
+    int tcpmss);
 
 /**
  * Sets the target/destination IP address of the packet, the destination port


### PR DESCRIPTION
There was a discussion about this a while back (https://github.com/robertdavidgraham/masscan/pull/326) and I ended up needing to add this for a few specific networks that appear to be deliberately dropping packets without TCP options. This is open upstream as https://github.com/robertdavidgraham/masscan/pull/646

Please feel free to rework it into something a little bit neater if you do want to merge it