### PR TITLE
Add an option in masscan to output the ordered list of CIDR ranges

### DIFF
--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -239,25 +239,27 @@ count_cidr_bits(struct Range *range, bool *exact)
 
     for (i=0; i<32; i++) {
         unsigned mask = 0xFFFFFFFF >> i;
-
+        if ((range->begin & mask) != 0) {
+            continue;
+        }
         /* if subnets are equal */
         if ((range->begin & ~mask) == (range->end & ~mask)) {
-            if ((range->begin & mask) == 0 && (range->end & mask) == mask) {
+            if ((range->end & mask) == mask) {
                 /* mask is exact, we englobe the whole range */
                 *exact = true;
                 return i;
             }
-        } else if ((range->begin & ~mask) != (range->end & ~mask)) {
+        } else {
             /* if subnets are different, we have been too far one bit */
             *exact = false;
             /* set the new range begining (that is not included
-             * in the mask we return */
+             * in the mask we return) */
             range->begin = range->begin + mask + 1;
             return i;
         }
     }
-
-    return 0;
+    range->begin += 1;
+    return 32;
 }
 
 /***************************************************************************

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -291,34 +291,46 @@ count_cidr_bits(struct Range *range, bool *exact)
 /***************************************************************************
  ***************************************************************************/
 static unsigned
-count_cidr6_bits(struct Range6 range)
+count_cidr6_bits(struct Range6 *range, bool *exact)
 {
+    /* for the comments of this function, see  count_cidr_bits */
+    *exact = false;
     uint64_t i;
 
-    /* the easy case: hi part of addresses are the same */
-    if (range.begin.hi == range.end.hi) {
-        for (i=0; i<64; i++) {
-            uint64_t mask = 0xFFFFFFFFffffffffull >> i;
-
-            if ((range.begin.lo & ~mask) == (range.end.lo & ~mask)) {
-                if ((range.begin.lo & mask) == 0 && (range.end.lo & mask) == mask)
-                    return (unsigned)64 + i;
+    for (i=0; i<128; i++) {
+        uint64_t mask_hi;
+        uint64_t mask_lo;
+        if (i < 64) {
+            mask_hi = 0xFFFFFFFFffffffffull >> i;
+            mask_lo = 0xFFFFFFFFffffffffull;
+        } else {
+            mask_hi = 0;
+            mask_lo = 0xFFFFFFFFffffffffull >> (i - 64);
+        }
+        if ((range->begin.hi & mask_hi) != 0 || (range->begin.lo & mask_lo) != 0) {
+            continue;
+        }
+        if ((range->begin.hi & ~mask_hi) == (range->end.hi & ~mask_hi) &&
+                (range->begin.lo & ~mask_lo) == (range->end.lo & ~mask_lo)) {
+            if (((range->end.hi & mask_hi) == mask_hi) && ((range->end.lo & mask_lo) == mask_lo)) {
+                *exact = true;
+                return (unsigned) i;
             }
-        }
-        return 0;
-    }
-    /* the tricky case: hi parts differ */
-    for (i=0; i<64; i++) {
-        uint64_t mask = 0xFFFFFFFFffffffffull >> i;
-
-        if ((range.begin.hi & ~mask) == (range.end.hi & ~mask)) {
-            if ((range.begin.hi & mask) == 0 && range.begin.lo == 0 && 
-                    (range.end.hi & mask) == mask && range.end.lo == 0xFFFFFFFFffffffffull)
-                return (unsigned)i;
+        } else {
+            *exact = false;
+            range->begin.hi = range->begin.hi + mask_hi;
+            if (range->begin.lo >= 0xffffffffffffffff - 1 - mask_lo) {
+                range->begin.hi += 1;
+            }
+            range->begin.lo = range->begin.lo + mask_lo + 1;
+            return (unsigned) i;
         }
     }
-
-    return 0;
+    range->begin.lo = range->begin.lo + 1;
+    if (range->begin.lo == 0) {
+        range->begin.hi = range->begin.hi + 1;
+    }
+    return 128;
 }
 
 
@@ -3286,14 +3298,15 @@ masscan_echo(struct Masscan *masscan, FILE *fp, unsigned is_echo_all)
         fprintf(fp, "\n");
     }
     for (i=0; i<masscan->targets.ipv6.count; i++) {
+        bool exact = false;
         struct Range6 range = masscan->targets.ipv6.list[i];
         ipaddress_formatted_t fmt = ipv6address_fmt(range.begin);
         
         fprintf(fp, "range = %s", fmt.string);
         if (!ipv6address_is_equal(range.begin, range.end)) {
-            unsigned cidr_bits = count_cidr6_bits(range);
+            unsigned cidr_bits = count_cidr6_bits(&range, &exact);
             
-            if (cidr_bits) {
+            if (exact && cidr_bits) {
                 fprintf(fp, "/%u", cidr_bits);
             } else {
                 fmt = ipv6address_fmt(range.end);
@@ -3336,10 +3349,19 @@ masscan_echo_cidr(struct Masscan *masscan, FILE *fp, unsigned is_echo_all)
     }
     for (i=0; i<masscan->targets.ipv6.count; i++) {
         struct Range6 range = masscan->targets.ipv6.list[i];
-        ipaddress_formatted_t fmt = ipv6address_fmt(range.begin);
-        unsigned cidr_bits = count_cidr6_bits(range);
-        fprintf(fp, "%s/%u", fmt.string, cidr_bits);
-        fprintf(fp, "\n");
+        bool exact = false;
+        while (!exact) {
+            ipaddress_formatted_t fmt = ipv6address_fmt(range.begin);
+            fprintf(fp, "%s", fmt.string);
+            if (range.begin.hi == range.end.hi && range.begin.lo == range.end.lo) {
+                fprintf(fp, "/128");
+                exact = true;
+            } else {
+                unsigned cidr_bits = count_cidr6_bits(&range, &exact);
+                fprintf(fp, "/%u", cidr_bits);
+            }
+            fprintf(fp, "\n");
+        }
     }
 }
 

--- a/src/main-conf.c
+++ b/src/main-conf.c
@@ -226,16 +226,34 @@ print_nmap_help(void)
 /***************************************************************************
  ***************************************************************************/
 static unsigned
-count_cidr_bits(struct Range range)
+count_cidr_bits(struct Range *range, bool *exact)
 {
+    /* if range is covered by exactly one cidr prefix,
+     * exact is set to true and the prefix is outputted.
+     * If not, exact is set to false and the output
+     * cidr is the biggest one that starts at
+     * range.begin and that is included in range
+     */
+    *exact = false;
     unsigned i;
 
     for (i=0; i<32; i++) {
         unsigned mask = 0xFFFFFFFF >> i;
 
-        if ((range.begin & ~mask) == (range.end & ~mask)) {
-            if ((range.begin & mask) == 0 && (range.end & mask) == mask)
+        /* if subnets are equal */
+        if ((range->begin & ~mask) == (range->end & ~mask)) {
+            if ((range->begin & mask) == 0 && (range->end & mask) == mask) {
+                /* mask is exact, we englobe the whole range */
+                *exact = true;
                 return i;
+            }
+        } else if ((range->begin & ~mask) != (range->end & ~mask)) {
+            /* if subnets are different, we have been too far one bit */
+            *exact = false;
+            /* set the new range begining (that is not included
+             * in the mask we return */
+            range->begin = range->begin + mask + 1;
+            return i;
         }
     }
 
@@ -2348,6 +2366,8 @@ masscan_set_parameter(struct Masscan *masscan,
         masscan->op = Operation_Echo;
     } else if (EQUALS("echo-all", name)) {
         masscan->op = Operation_EchoAll;
+    } else if (EQUALS("echo-cidr", name)) {
+        masscan->op = Operation_EchoCidr;
     } else if (EQUALS("excludefile", name)) {
         unsigned count1 = masscan->exclude.ipv4.count;
         unsigned count2;
@@ -2604,7 +2624,7 @@ static int
 is_singleton(const char *name)
 {
     static const char *singletons[] = {
-        "echo", "echo-all", "selftest", "self-test", "regress",
+        "echo", "echo-all", "echo-cidr", "selftest", "self-test", "regress",
         "benchmark",
         "system-dns", "traceroute", "version",
         "version-light",
@@ -3213,6 +3233,7 @@ masscan_echo(struct Masscan *masscan, FILE *fp, unsigned is_echo_all)
     }
     fprintf(fp, "\n");
     for (i=0; i<masscan->targets.ipv4.count; i++) {
+        bool exact = false;
         struct Range range = masscan->targets.ipv4.list[i];
         fprintf(fp, "range = ");
         fprintf(fp, "%u.%u.%u.%u",
@@ -3222,9 +3243,9 @@ masscan_echo(struct Masscan *masscan, FILE *fp, unsigned is_echo_all)
                 (range.begin>> 0)&0xFF
                 );
         if (range.begin != range.end) {
-            unsigned cidr_bits = count_cidr_bits(range);
-            
-            if (cidr_bits) {
+            unsigned cidr_bits = count_cidr_bits(&range, &exact);
+
+            if (exact && cidr_bits) {
                 fprintf(fp, "/%u", cidr_bits);
             } else
                 fprintf(fp, "-%u.%u.%u.%u",
@@ -3255,6 +3276,44 @@ masscan_echo(struct Masscan *masscan, FILE *fp, unsigned is_echo_all)
     }    
 }
 
+/***************************************************************************
+ * Prints the list of CIDR to scan to the command-line then exits.
+ * Use: provide this list to other tools. Unlike masscan -sL, it keeps
+ * the CIDR aggretated format, and does not randomize the order of output.
+ ***************************************************************************/
+void
+masscan_echo_cidr(struct Masscan *masscan, FILE *fp, unsigned is_echo_all)
+{
+    unsigned i;
+    masscan->echo = fp;
+    for (i=0; i<masscan->targets.ipv4.count; i++) {
+        struct Range range = masscan->targets.ipv4.list[i];
+        bool exact = false;
+        while (!exact) {
+            fprintf(fp, "%u.%u.%u.%u",
+                    (range.begin>>24)&0xFF,
+                    (range.begin>>16)&0xFF,
+                    (range.begin>> 8)&0xFF,
+                    (range.begin>> 0)&0xFF
+                    );
+            if (range.begin == range.end) {
+                fprintf(fp, "/32");
+                exact = true;
+            } else {
+                unsigned cidr_bits = count_cidr_bits(&range, &exact);
+                fprintf(fp, "/%u", cidr_bits);
+            }
+            fprintf(fp, "\n");
+        }
+    }
+    for (i=0; i<masscan->targets.ipv6.count; i++) {
+        struct Range6 range = masscan->targets.ipv6.list[i];
+        ipaddress_formatted_t fmt = ipv6address_fmt(range.begin);
+        unsigned cidr_bits = count_cidr6_bits(range);
+        fprintf(fp, "%s/%u", fmt.string, cidr_bits);
+        fprintf(fp, "\n");
+    }
+}
 
 /***************************************************************************
  * remove leading/trailing whitespace
@@ -3348,12 +3407,14 @@ mainconf_selftest()
 
         range.begin = 16;
         range.end = 32-1;
-        if (count_cidr_bits(range) != 28)
+        bool exact = false;
+        if (count_cidr_bits(&range, &exact) != 28 || !exact)
             return 1;
 
+        exact = true;
         range.begin = 1;
         range.end = 13;
-        if (count_cidr_bits(range) != 0)
+        if (count_cidr_bits(&range, &exact) != 0 || !exact)
             return 1;
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -1816,6 +1816,11 @@ int main(int argc, char *argv[])
         exit(0);
         break;
 
+    case Operation_EchoCidr:
+        masscan_echo_cidr(masscan, stdout, 0);
+        exit(0);
+        break;
+
     case Operation_Selftest:
         /*
          * Do a regression test of all the significant units

--- a/src/masscan.h
+++ b/src/masscan.h
@@ -36,6 +36,7 @@ enum Operation {
     Operation_Benchmark = 8,        /* --benchmark */
     Operation_Echo = 9,             /* --echo */
     Operation_EchoAll = 10,         /* --echo-all */
+    Operation_EchoCidr = 11,        /* --echo-cidr */
 };
 
 /**
@@ -535,5 +536,11 @@ masscan_initialize_adapter(
  */
 void
 masscan_echo(struct Masscan *masscan, FILE *fp, unsigned is_echo_all);
+
+/**
+ * Echoes the list of CIDR ranges to scan.
+ */
+void
+masscan_echo_cidr(struct Masscan *masscan, FILE *fp, unsigned is_echo_all);
 
 #endif


### PR DESCRIPTION
If I am not mistaken, there is currently no option in **masscan** to output the list of IP ranges to be scanned:

* ordered by numerical order of the first IP of each range
* only using CIDR notations (`<first ip>/<mask>`).

Indeed, the option `-sL` outputs a list of IP addresses (not ranges) in a random order, and `--echo` outputs **masscan** configuration, including ranges but also other options, and in a non-consistent format.

This PR adds the option `--echo-cidr` that outputs the the ordered list of CIDR ranges.
For instance, with the following list of IP addresses to scan:

```
10.0.0.0-10.0.1.15
192.168.0.0-192.168.0.3
192.168.1.2-192.168.1.3
```

* `masscan -iL ips.txt --echo-cidr`
```
10.0.0.0/24
10.0.1.0/28
192.168.0.0/30
192.168.1.2/31
```

* `masscan -iL ips.txt -sL | head -n 10`
```
10.0.0.111
10.0.0.61
10.0.0.82
192.168.0.3
10.0.0.190
10.0.0.214
10.0.0.121
10.0.0.42
10.0.0.193
10.0.1.4
```

* `masscan -iL ips.txt --echo`
```
seed = 7008350106479622823
rate = 100       
shard = 1/1
nocapture = servername
nocapture = servername


# TARGET SELECTION (IP, PORTS, EXCLUDES)
ports = 
range = 10.0.0.0-10.0.1.15
range = 192.168.0.0/30
range = 192.168.1.2/31
```