### PR TITLE
Update TLS banner to go from 1.0 to 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,26 @@
-[![Build Status](https://travis-ci.org/robertdavidgraham/masscan.svg?branch=master)](https://travis-ci.org/robertdavidgraham/masscan.svg)
+# IVRE's fork
+
+This fork is maintained by the IVRE project. **If you are looking for
+the original Masscan, see the
+[official repository](https://github.com/robertdavidgraham/masscan)**.
+
+This fork contains a set of patches mostly useful to gather more data
+for [IVRE](https://ivre.rocks/). **It is often rebased against the
+original's master branch, so ``git pull``s will fail or result in
+useless merges**. Fetch the changes to a new local branch or simply
+download an archive to update it.
+
+Some of the patches in this repository will **not** be useful unless
+you use the results with IVRE.
+
+To get a list of the patches, use ``git log -p``.
+
+This fork is currently based on the following commit:
+```
+commit 144c527ed55275ee9fbb80bb14fbb5e3fcff3b7e
+Author: Robert David Graham <robert_david_graham@yahoo.com>
+Date:   Sun Sep 5 23:26:49 2021 -0400
+```
 
 # MASSCAN: Mass IP port scanner
 

--- a/src/proto-banner1.c
+++ b/src/proto-banner1.c
@@ -607,7 +607,7 @@ banner1_create(void)
     banner_smtp.init(b);
     banner_ssh.init(b);
     banner_ssl.init(b);
-    banner_ssl_12.init(b);
+    banner_tls_13.init(b);
     banner_smb0.init(b);
     banner_smb1.init(b);
     banner_telnet.init(b);
@@ -782,12 +782,6 @@ banner1_selftest()
             return 1;
         }
 
-        x = banner_ssl_12.selftest();
-        if (x) {
-            fprintf(stderr, "SSL banner: selftest failed\n");
-            return 1;
-        }
-        
         x = banner_smb1.selftest();
         if (x) {
             fprintf(stderr, "SMB banner: selftest failed\n");

--- a/src/proto-banout.c
+++ b/src/proto-banout.c
@@ -323,6 +323,69 @@ banout_append(struct BannerOutput *banout, unsigned proto,
 
 }
 
+/***************************************************************************
+ ***************************************************************************/
+unsigned
+banout_replacefirst(struct BannerOutput *banout, unsigned proto,
+                    const char *string, const char *replace)
+{
+    struct BannerOutput *p;
+
+    char* first_instance;
+    size_t string_length;
+    size_t replace_length;
+
+    if (string == NULL)
+        return 0;
+
+    string_length = strlen(string);
+
+    if (replace == NULL)
+        return 0;
+
+    replace_length = strlen(replace);
+
+    /*
+     * Get the matching record for the protocol (e.g. HTML, SSL, etc.).
+     */
+    p = banout_find_proto(banout, proto);
+    if (p == NULL) {
+        return 0;
+    }
+
+    /*
+     * Find the string in the banout.
+     */
+    first_instance = strstr((char*) p->banner, string);
+    size_t offset = ((unsigned) (first_instance - (char*) p->banner));
+    if (first_instance == NULL) {
+        return 0;
+    }
+
+    /*
+     * If the current object isn't big enough, expand it
+     */
+    while (p->length + replace_length - string_length >= p->max_length) {
+        p = banout_expand(banout, p);
+    }
+
+    /*
+     * Now that we are assured there is enough space, do the replacement
+     */
+    p->length = (unsigned)(p->length + replace_length - string_length);  // can't be <0 because strstr != NULL
+    memcpy(
+        first_instance + replace_length,
+        first_instance + string_length,
+        p->length - offset - string_length
+    );
+    memcpy(
+        first_instance,
+        replace,
+        replace_length
+    );
+    return 1;
+}
+
 /*****************************************************************************
  *****************************************************************************/
 static const char *b64 =

--- a/src/proto-banout.h
+++ b/src/proto-banout.h
@@ -75,6 +75,14 @@ banout_append_hexint(struct BannerOutput *banout, unsigned proto, unsigned long 
 void
 banout_append_unicode(struct BannerOutput *banout, unsigned proto, unsigned c);
 
+/*
+ * Replace first occurence of string with another string inside the banner.
+ * This function should only be used when banout represents a string,
+ * and not a X.509 certificate.
+ */
+unsigned
+banout_replacefirst(struct BannerOutput *banout, unsigned proto, const char *string, const char *replace);
+
 /**
  * Select a specific string (of the specified protocol).
  * The "banner output" can have multiple protocol objects associated

--- a/src/proto-ssl.h
+++ b/src/proto-ssl.h
@@ -3,7 +3,7 @@
 #include "proto-banner1.h"
 
 extern struct ProtocolParserStream banner_ssl;
-extern struct ProtocolParserStream banner_ssl_12;
+extern struct ProtocolParserStream banner_tls_13;
 
 extern const char *ssl_hello_heartbeat_template;
 extern const char *ssl_hello_ticketbleed_template;

--- a/src/proto-tcp.c
+++ b/src/proto-tcp.c
@@ -1295,7 +1295,7 @@ application(struct TCP_ConnectionTable *tcpcon,
                      * Kludge
                      */
                     if (banner1->payloads.tcp[tcb->port_them] == &banner_ssl ||
-                            banner1->payloads.tcp[tcb->port_them] == &banner_ssl_12) {
+                            banner1->payloads.tcp[tcb->port_them] == &banner_tls_13) {
                         tcb->banner1_state.is_sent_sslhello = 1;
                     }
                     


### PR DESCRIPTION
- update the TLS 1.2 banner to work from TLS 1.0 to TLS 1.2 (inspired by PR 668 of robert's masscan)
- send the TLS 1.3 banner slightly modified to support a wider range of versions